### PR TITLE
调整 Agent 概念博文 Mermaid 样式

### DIFF
--- a/_posts/2026-08-01-Agent基本概念梳理.md
+++ b/_posts/2026-08-01-Agent基本概念梳理.md
@@ -52,9 +52,11 @@ excerpt: "围绕 LLM、Prompt、Context Window、Memory、Agent、Function Calli
 5. 再往后，是多步任务如何固化：从**确定性编排**、**低代码工作流**，到 **Skill**、再到更自由的 Agent 循环；
 6. 最后落到产品形态：CLI、IDE 插件、桌面助手等。
 
-<div class="mermaid" style="display: flex; justify-content: center; width: 90%; margin: 0 auto;">
+<div class="mermaid" style="display: flex; justify-content: center; width: 100%; margin: 0 auto;">
 flowchart BT
-    classDef default fill:#fff,stroke:#333,stroke-width:1px,color:#000;
+    classDef base fill:#ECEFF1,stroke:#455A64,color:#222
+    classDef agent fill:#E3F2FD,stroke:#1565C0,color:#222
+    classDef product fill:#FFF3E0,stroke:#EF6C00,color:#222
 
     P1["① LLM<br/>大语言模型 / 自回归生成"] --> P2["② Prompt<br/>送入模型的输入"]
     P2 --> P3["③ Context Window<br/>有限上下文窗口"]
@@ -66,9 +68,13 @@ flowchart BT
     P5 --> P9["⑨ 确定性编排 / Workflow / Skill<br/>多步任务如何固化"]
     P5 --> P10["⑩ SubAgent<br/>子任务与上下文隔离"]
     P5 --> P11["⑪ 产品形态<br/>CLI / IDE / 桌面助手"]
+
+    class P1,P2,P3,P4 base
+    class P5,P6,P7,P8,P9,P10 agent
+    class P11 product
 </div>
 
-<em>图 1：从 LLM 往上叠出来的概念层</em>
+<p align="center"><em>图 1：从 LLM 往上叠出来的概念层</em></p>
 
 
 # 对话层：Prompt、Context Window、Memory
@@ -112,9 +118,13 @@ Harness ≈ 围在模型周围的那一层：提示词、工具列表、中间�
 
 所以把 Agent 理解成「编排器 + 传话筒」并不错，但要补一句：循环里做决策的仍然是模型；程序侧解决的是可控执行与工程封装。早期一些所谓 Agent，实现上可能只是多包了一层 Prompt 模板——名词很新，底层未必复杂。
 
-<div class="mermaid" style="display: flex; justify-content: center; width: 90%; margin: 0 auto;">
+<div class="mermaid" style="display: flex; justify-content: center; width: 100%; margin: 0 auto;">
 flowchart TB
-    classDef default fill:#fff,stroke:#333,stroke-width:1px,color:#000;
+    classDef user fill:#FFF3E0,stroke:#E65100,color:#222
+    classDef host fill:#E3F2FD,stroke:#1565C0,color:#222
+    classDef model fill:#F3E5F5,stroke:#6A1B9A,color:#222
+    classDef tool fill:#E8F5E9,stroke:#2E7D32,color:#222
+    classDef mem fill:#FFF8E1,stroke:#F9A825,color:#222
 
     U["你 / 自然语言任务"] <-->|"CLI / IDE / 桌面助手"| H["Host / Harness<br/>拼装上下文 · 执行工具 · 控制循环"]
     H --- MEM["Memory"]
@@ -123,9 +133,15 @@ flowchart TB
     H <-->|"Function / Tool Calling"| L["LLM<br/>决策与生成"]
     H <-->|"MCP Client"| S["MCP Server<br/>Tools / Resources / Prompts"]
     H --- RAG["RAG / Web Search<br/>检索后回填上下文"]
+
+    class U user
+    class H,MEM,SK,SUB host
+    class L model
+    class S tool
+    class RAG mem
 </div>
 
-<em>图 2：人、Host/Harness、LLM、MCP 与检索能力的相对位置</em>
+<p align="center"><em>图 2：人、Host/Harness、LLM、MCP 与检索能力的相对位置</em></p>
 
 
 # 能力扩展：Web Search 与 RAG
@@ -182,16 +198,24 @@ flowchart TB
 
 现实任务很少是单轮问答。比如：从英文 PDF 抽文本 → 翻译成中文 → 存成 Markdown。这类多阶段流程，至少有四种常见落法。
 
-<div class="mermaid" style="display: flex; justify-content: center; width: 90%; margin: 0 auto;">
+<div class="mermaid" style="display: flex; justify-content: center; width: 100%; margin: 0 auto;">
 flowchart LR
-    classDef default fill:#fff,stroke:#333,stroke-width:1px,color:#000;
+    classDef rigid fill:#FFCDD2,stroke:#C62828,color:#222
+    classDef mid fill:#FFE0B2,stroke:#EF6C00,color:#222
+    classDef soft fill:#C8E6C9,stroke:#2E7D32,color:#222
+    classDef flex fill:#BBDEFB,stroke:#1565C0,color:#222
 
     LC["确定性编排<br/>代码/Chain 写死步骤<br/>最稳定 / 难包容变化"] -->|"更柔性"| WF["Workflow<br/>低代码拖拽<br/>好改一点 / 仍偏程序控"]
     WF -->|"更柔性"| SK["Skill<br/>SKILL.md + 资源/脚本<br/>模型按需加载 / 有约束"]
     SK -->|"更柔性"| PA["开放 Agent 循环<br/>动态拆解与自写脚本<br/>最灵活 / 易失控"]
+
+    class LC rigid
+    class WF mid
+    class SK soft
+    class PA flex
 </div>
 
-<em>图 3：确定性编排 → Workflow → Skill → 开放 Agent，刚性递减、柔性递增</em>
+<p align="center"><em>图 3：确定性编排 → Workflow → Skill → 开放 Agent，刚性递减、柔性递增</em></p>
 
 ## 1. 确定性编排（常以代码 / Chain 实现）
 
@@ -245,9 +269,12 @@ flowchart LR
 
 把上面几层合在一起，一次典型调用更像这样：
 
-<div class="mermaid" style="display: flex; justify-content: center; width: 90%; margin: 0 auto;">
+<div class="mermaid" style="display: flex; justify-content: center; width: 100%; margin: 0 auto;">
 flowchart LR
-    classDef default fill:#fff,stroke:#333,stroke-width:1px,color:#000;
+    classDef user fill:#FFF3E0,stroke:#E65100,color:#222
+    classDef host fill:#E3F2FD,stroke:#1565C0,color:#222
+    classDef model fill:#F3E5F5,stroke:#6A1B9A,color:#222
+    classDef tool fill:#FFF8E1,stroke:#F9A825,color:#222
 
     U["人"] -->|"自然语言"| H["Host / Harness"]
     H -->|"组装 Prompt<br/>Memory / RAG / Skill"| L["LLM"]
@@ -255,9 +282,14 @@ flowchart LR
     H -->|"本地工具或 MCP call"| T["Tools / Servers"]
     T -->|"结果回填上下文"| H
     H -->|"最终答复"| U
+
+    class U user
+    class H host
+    class L model
+    class T tool
 </div>
 
-<em>图 4：人 → Host → LLM / Tools → 回填上下文 → 最终答复</em>
+<p align="center"><em>图 4：人 → Host → LLM / Tools → 回填上下文 → 最终答复</em></p>
 
 对应到职责划分：
 
@@ -268,9 +300,12 @@ flowchart LR
 
 # 易混概念对照
 
-<div class="mermaid" style="display: flex; justify-content: center; width: 90%; margin: 0 auto;">
+<div class="mermaid" style="display: flex; justify-content: center; width: 100%; margin: 0 auto;">
 flowchart TB
-    classDef default fill:#fff,stroke:#333,stroke-width:1px,color:#000;
+    classDef a fill:#E3F2FD,stroke:#1565C0,color:#222
+    classDef b fill:#E8F5E9,stroke:#2E7D32,color:#222
+    classDef c fill:#F3E5F5,stroke:#6A1B9A,color:#222
+    classDef ok fill:#FFF8E1,stroke:#F9A825,color:#222
 
     subgraph P1["易混对照 ①：不在同一层"]
       FC["Function / Tool Calling"] -->|"宿主与 LLM"| FC2["模型提出结构化工具请求<br/>由程序真正执行"]
@@ -288,9 +323,14 @@ flowchart TB
 
     P1 --> X1
     P2 --> X2
+
+    class FC,SK a
+    class MCP1,MCP2 b
+    class FC2,MCP12,SK2,MCP22 c
+    class X1,X2 ok
 </div>
 
-<em>图 5：Function Calling vs MCP；Skill vs MCP</em>
+<p align="center"><em>图 5：Function Calling vs MCP；Skill vs MCP</em></p>
 
 再补一张简表：
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 改动说明

更新 `_posts/2026-08-01-Agent基本概念梳理.md` 中的 Mermaid 配图样式：

1. **着色**：去掉强制白底黑框的 `classDef default`，按层级/角色分色（基础层、Agent 层、产品层、刚性→柔性谱系等）
2. **宽度**：图容器由 `90%` 改为 `100%`
3. **图题居中**：改为 `<p align="center"><em>图 x：...</em></p>`

请审阅合并；合并后我会删除临时分支 `cursor-agent`。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-35a68d79-a791-4f54-9a0b-f17e48c90cbe?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35a68d79-a791-4f54-9a0b-f17e48c90cbe&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

