### PR TITLE
重写 Agent 概念博文：融入视频脉络并改写

### DIFF
--- a/_posts/2026-08-01-Agent基本概念梳理.md
+++ b/_posts/2026-08-01-Agent基本概念梳理.md
@@ -6,7 +6,7 @@ tags: [Coding]
 comments: true
 author: kwanwaipang
 toc: true
-excerpt: "围绕 LLM、Prompt、Context Window、Memory、Agent、Function Calling、MCP、RAG、Skill、Workflow 等概念，梳理智能体系统的分层结构、易混关系与流程固化谱系，便于后续阅读 OpenClaw / LangGraph 等实践笔记。"
+excerpt: "从 LLM 的文字接龙讲起，顺着 Prompt、Memory、Agent、RAG、Function Calling、MCP、Skill、Workflow 一路往上，梳理这些名词各自解决什么问题、落在哪一层接口，以及为何经常被拿来错误对比。"
 ---
 
 
@@ -16,13 +16,15 @@ excerpt: "围绕 LLM、Prompt、Context Window、Memory、Agent、Function Calli
 
 # 引言
 
-最近接触 OpenClaw、LangGraph、Skill、MCP 这类词的频率明显上升。名词一多，就很容易陷入「每个词都很眼熟，串起来却说不清」的状态：Agent 到底是模型还是程序？Function Calling 和 MCP 是不是一回事？Skill 又该放在哪一层？
+最近 OpenClaw、Skill、MCP、RAG、Function Calling 这些词同时出现的频率很高。读多了之后反而容易有一种熟悉的眩晕感：每个词都好像懂一点，真正要解释「它们差在哪一层」时，又经常卡住。
 
-本博文尝试把这些概念重新组织成一条可读的主线，重点不在追新词，而在弄清：
+本博文想做的事情比较朴素：把这些概念按「问题是怎么一步步长出来的」重新串一遍。重点不是背名词，而是弄清三件事：
 
-1. 每个名词解决的是哪一类问题；
-2. 它们分别落在人、程序、模型、工具之间的哪一段接口上；
-3. 哪些概念容易被拿来对比，其实并不在同一维度。
+1. 每个词当初是为了补哪块短板；
+2. 它落在人、宿主程序、模型、外部能力之间的哪一段接口上；
+3. 哪些对比本身就不在同一维度。
+
+写完以后会发现，很多新词并没有发明全新智能，而更像是在同一条工程链路上不断打补丁、起名字、做封装。
 
 > **参考**：概念脉络参考了飞天闪客的视频[《一口气拆穿 Skill/MCP/RAG/Agent/OpenClaw 底层逻辑》](https://www.bilibili.com/video/BV1ojfDBSEPv/)。下文为本人整理与改写，仅供学习记录。
 
@@ -31,92 +33,134 @@ excerpt: "围绕 LLM、Prompt、Context Window、Memory、Agent、Function Calli
 * [什么是LangGraph？](/什么是LangGraph？/)
 
 
-# 一条主线：先有接龙，再有系统
+# 先立一个总判断
 
-如果把智能体相关技术压成一句不太严谨、但很管用的话：
+如果只能先记住一句不太严谨、但很管用的话：
 
 ~~~
 模型负责在不确定处做判断与生成；
 宿主程序负责循环调度、执行工具、拼装上下文；
-所谓 Agent，通常就是「模型 + 外围 harness」一起转起来的系统。
+所谓 Agent，常常就是「模型 + 外围 harness」一起转起来的系统。
+更狠一点说：Agent 里很多部件，恰恰是那些「不必交给智能」的部分。
 ~~~
 
-更具体一点，可以按下面这条生长线来看：
-
-1. 先有 **LLM**：在给定上下文中做自回归生成（预测后续 token）；
-2. 再有 **Prompt / Context Window / Memory**：把单次生成包装成可用的多轮交互；
-3. 然后出现 **Agent**：模型在循环中调用工具，直到任务结束；
-4. 接着分化出两套常被混谈的机制：
-   * **Function Calling / Tool Calling**：模型如何以结构化方式提出工具调用请求；
-   * **MCP**：宿主应用如何以标准协议发现并接入外部能力（工具、资源、提示模板等）；
-5. 再往后，是多步任务如何固化：从**确定性编排**、**低代码工作流**，到 **Skill**、再到更自由的 Agent 循环；
-6. 最后落到产品形态：CLI、IDE 插件、桌面助手等。
-
-<div class="mermaid" style="display: flex; justify-content: center; width: 100%; margin: 0 auto;">
-flowchart BT
-    classDef base fill:#ECEFF1,stroke:#455A64,color:#222
-    classDef agent fill:#E3F2FD,stroke:#1565C0,color:#222
-    classDef product fill:#FFF3E0,stroke:#EF6C00,color:#222
-
-    P1["① LLM<br/>大语言模型 / 自回归生成"] --> P2["② Prompt<br/>送入模型的输入"]
-    P2 --> P3["③ Context Window<br/>有限上下文窗口"]
-    P3 --> P4["④ Memory<br/>短长期记忆与上下文管理"]
-    P4 --> P5["⑤ Agent<br/>模型 + harness 循环调工具"]
-    P5 --> P6["⑥ RAG / Web Search<br/>检索外部信息增强生成"]
-    P5 --> P7["⑦ Function Calling<br/>模型提出结构化工具请求"]
-    P5 --> P8["⑧ MCP<br/>宿主与外部能力的标准协议"]
-    P5 --> P9["⑨ 确定性编排 / Workflow / Skill<br/>多步任务如何固化"]
-    P5 --> P10["⑩ SubAgent<br/>子任务与上下文隔离"]
-    P5 --> P11["⑪ 产品形态<br/>CLI / IDE / 桌面助手"]
-
-    class P1,P2,P3,P4 base
-    class P5,P6,P7,P8,P9,P10 agent
-    class P11 product
-</div>
-
-<p align="center"><em>图 1：从 LLM 往上叠出来的概念层</em></p>
+后面所有名词，大体都在围着这句话长出来。
 
 
-# 对话层：Prompt、Context Window、Memory
+# 从接龙开始：LLM、对话、Prompt
 
-## LLM 本身能做什么
+混乱的起点仍然是语言模型。参数较小时，它更像勉强续写的机器；参数大到某个临界点后，涌现出更强的指令跟随与推理表现。为了和更早的小模型区分，前面加了个「大」字，于是有了今天常说的 **LLM（Large Language Model）**。
 
-LLM（Large Language Model）的核心机制是**自回归条件生成**：在已有 token 序列上，不断预测下一个 token。单独调用时，它更像「续写引擎」；之所以后来看起来像能聊天，是因为工程上把输入输出组织成了角色轮次（system / user / assistant），并在产品层做了多轮会话封装。
+但 LLM 的基本机制并没有变：它是在给定上下文中做**自回归生成**，不断预测下一个 token。如果只拿它做裸续写，体验仍然很差。工程上真正让它「看起来会聊天」的第一步，是人为切出角色边界——把交互组织成一问一答。
 
-这里有两个常被忽略的约束：
+这里有个后面会反复用到的约束：
 
-* 单次 API 调用通常仍是「给定上下文 → 生成一段输出」；
-* 模型本身一般不持有跨请求的持久状态；所谓「记住刚才说的话」，多半是宿主程序把历史重新放进下一次请求的上下文窗口。
+~~~
+模型调用本身通常仍是「一次请求、一次回复」。
+它并不能天然地一边聊一边主动追问；
+所谓多轮，往往是宿主在下一次请求前，把历史重新塞回上下文。
+~~~
 
-## Prompt / Context Window / Memory 分别指什么
+于是你可以把模型想象成一个能力很强、但服务方式很奇怪的员工：只会接一次任务单，办完就交卷。接下来的全部工程，其实都是在想办法压榨这个「只会一问一答」的员工。
 
-| 概念 | 更贴切的理解 |
-|---|---|
-| **Prompt** | 这一次真正送进模型的输入（可包含系统提示、用户问题、工具结果、检索片段等） |
-| **Context Window** | 模型一次能处理的上下文长度上限；所有历史、资料、工具返回都要挤进这个窗口 |
-| **Memory** | 为跨轮次/跨任务保持连续性而做的状态管理：短时可直接回放对话，长时可外置存储后再检索回填 |
+首先，给每次输入起了个名字，叫 **Prompt**。再进一步拆开后会发现，Prompt 里通常至少有两类东西：
 
-因此，产品里说的 Memory，通常不是「模型参数里凭空长出了记忆」，而是一套上下文管理策略：完整回放、摘要压缩、关键事实抽取、外部记忆库召回等，都是在有限窗口里做取舍。
+* 背景信息、约束、资料；
+* 最终要模型完成的指示。
+
+前者常被单独称作 **Context**。而模型一次能吞下的总量，则受 **Context Window** 限制——历史、检索结果、工具返回、说明文档，最终都要挤进这个窗口。
+
+
+# 假多轮是怎样做出来的：Memory
+
+既然模型不能真正「记住」上轮对话，要追问怎么办？常见做法很直接：
+
+1. 把此前的对话历史整理好；
+2. 放进下一次请求的 Context；
+3. 再追加当前问题。
+
+于是表面上出现了连续对话，底层仍是单次生成。人们给这种「靠回填历史维持连续性」的机制起名叫 **Memory**。
+
+Memory 还可以继续演化：完整回放太占窗口时，就做摘要压缩；跨会话要长期保留时，就把关键事实外置存储，需要时再检索回来。所以产品里的 Memory，通常不是「模型参数里突然长出了记忆」，而是一套上下文管理策略。
 
 > **NOTE：**  
-> 后面很多能力——联网搜索结果、RAG 检索片段、Skill 说明文档——工程上常常落成同一类动作：**在合适的时机，把额外信息写进 Prompt / Context**。
+> 后面几乎所有花活——搜索结果、RAG 片段、Skill 文档——工程上常常落成同一类动作：**在合适时机，自动往 Prompt / Context 里补信息**。
 
 
-# 代理层：Agent 到底是什么
+# 模型不会上网，怎么办：Agent 出场
 
-关于 Agent，一个比较干净的工程定义是：
+有了多轮对话之后，下一个缺口很快出现：模型没有实时查阅资料的能力，要么不知道，要么一本正经胡说，要么只能复述过时知识。
+
+最天真的想法是「给模型一台电脑」。但模型本身只会生成文本，不会独立完成外部动作。于是折中方案变成：
+
+* 让模型在需要查资料时提出请求；
+* 由一段程序去真正搜索；
+* 再把结果回填给模型继续生成。
+
+对外看，用户仍然像在「一问一答」；对内看，中间已经多了一层代理程序。当这层程序不仅能搜网页，还能读写文件、调 API、跑脚本时，它看起来就像拥有了「能操作工具的更高智能」。人们给它起名叫 **Agent（智能体）**。
+
+一个比较干净的工程定义是：
 
 ~~~
 Agent ≈ 模型在循环中调用工具，直到任务完成；
 Harness ≈ 围在模型周围的那一层：提示词、工具列表、中间件、状态与终止条件。
 ~~~
 
-也就是说，Agent 不是「另一个比 LLM 更神秘的大脑」，而更接近 **Model + Harness**：
+也就是说，Agent 不是另一个更神秘的大脑，而更接近 **Model + Harness**：
 
 * 模型负责理解目标、选择下一步、提出工具调用或给出最终回答；
-* Harness / 宿主程序负责组织上下文、真正执行工具、把结果喂回模型、控制循环何时结束。
+* 宿主程序负责组织上下文、真正执行工具、把结果喂回模型、控制循环何时结束。
 
-所以把 Agent 理解成「编排器 + 传话筒」并不错，但要补一句：循环里做决策的仍然是模型；程序侧解决的是可控执行与工程封装。早期一些所谓 Agent，实现上可能只是多包了一层 Prompt 模板——名词很新，底层未必复杂。
+早期一些所谓 Agent，实现上可能只是多包了一层 Prompt 模板。名词很新，底层未必复杂——这也是后来大家对概念通胀格外警惕的原因。
+
+
+# 本地知识怎么接进来：Search 与 RAG
+
+既然 Agent 已经能代理外部动作，下一步很自然：除了上网，能不能搜本地文档和数据库？
+
+可以。只不过私有知识检索常常不是传统关键词查询，而是先把文本做成向量，再按语义相似度召回相关片段。把「检索到的证据」与用户问题一起交给模型生成，就是 **RAG（Retrieval-Augmented Generation）**。
+
+视频里会把 Web Search、RAG 都归进一个更大的筐：**获取模型参数以外的信息**。这个归类偏工程直觉，不一定是学术上的严格分类，但很有助于理解——它们解决的都是「只靠参数记忆不够」的问题。
+
+需要补两句准确边界：
+
+1. RAG 的目标是让生成建立在外部证据上，而不是只靠训练知识；
+2. **向量数据库**是常见实现，但不是唯一实现；BM25、混合检索、知识图谱等也可以做 Retriever。
+
+检索质量仍然决定上限。RAG 能降低胡编概率，不会自动保证正确。
+
+
+# 模型和程序怎么说话：Function Calling
+
+当 Agent 需要稳定地调用工具时，如果模型和宿主之间一直用自然语言沟通，程序会很难解析。于是需要一套约定：让模型在需要外部能力时，输出**可解析的结构化请求**（工具名 + 参数），而不是只吐一段自由发挥的话。
+
+这就是 **Function Calling**，现在也常叫 **Tool Calling**。
+
+关键事实只有一句：
+
+~~~
+模型不负责真正执行函数；
+它只提出调用请求；
+宿主程序执行完后，再把结果作为后续上下文喂回模型。
+~~~
+
+没有这类机制，宿主就得靠脆弱的文本解析去猜意图，工程上很难做稳。它很像前后端约定好接口字段：约定清楚，系统才能自动流转。
+
+
+# 工具如何外置成服务：MCP
+
+一开始，工具实现常常直接写在 Agent 主程序里。这样简单，但难复用、难解耦。一旦希望把工具拆成独立服务，让不同 AI 应用都能发现和调用，就又需要一套标准协议。
+
+这就是 **MCP（Model Context Protocol）** 要解决的问题。更完整一点看，它通常不是「只有 tools」这么窄：
+
+* 架构上常见 **Host（宿主应用）— Client（连接层）— Server（能力提供方）**；
+* Server 可暴露：
+  * **Tools**：可执行动作；
+  * **Resources**：可读的上下文数据；
+  * **Prompts**：可复用提示模板；
+* 工具侧最常提到的动作是 `tools/list`、`tools/call`；通信多基于 JSON-RPC。
+
+至此，一张更清楚的位置关系是：
 
 <div class="mermaid" style="display: flex; justify-content: center; width: 100%; margin: 0 auto;">
 flowchart TB
@@ -141,164 +185,150 @@ flowchart TB
     class RAG mem
 </div>
 
-<p align="center"><em>图 2：人、Host/Harness、LLM、MCP 与检索能力的相对位置</em></p>
+<p align="center"><em>图 1：人、Host/Harness、LLM、MCP 与检索能力的相对位置</em></p>
+
+可以很粗地记：
+
+* 大模型像个「会说话、不会直接动手」的智者；
+* MCP Server 提供各种可调用能力；
+* 中间的 Host / Agent 更像传话筒与调度器——把模型意图翻译成工具调用，再把结果原路送回，同时继续服务你这个老板。
+
+主打一个：它未必生产智能，但它搬运上下文、执行确定动作、组织整条链路。
 
 
-# 能力扩展：Web Search 与 RAG
+# 交互形态：从 CLI 到 OpenClaw
 
-模型参数里没有、或不够新/不够私有的信息，就需要在推理时从外部拿。常见两条路径：
+同样一套 Agent 能力，交互外壳可以完全不同：
 
-1. **Web Search**：联网检索公开网页或搜索引擎结果，再把摘要/片段回填给模型；
-2. **RAG（Retrieval-Augmented Generation）**：先从指定知识源检索相关内容，再把检索结果与问题一起交给模型生成回答。它要解决的是：让生成建立在外部证据之上，而不是只靠参数记忆。
+* 像 CLI 一样的命令行窗口；
+* 编程 IDE 里的编码助手；
+* 更通用的桌面助手，例如最近很火的 CloudBot / OpenClaw 一类产品。
 
-实现 RAG 时，**向量数据库 + embedding 相似度检索**非常常见，但不是唯一做法；稀疏检索（如 BM25）、混合检索、知识图谱等也可以承担「Retriever」角色。需要强调的是：RAG 能降低胡编概率、便于注入私有知识，但**检索质量仍决定上限**，它不会自动保证事实正确。
+这里值得单独提一句命名带来的误解。以 Claude Code 为例，很多人第一眼会以为那是某个模型名；实际上它首先是编程场景下的 Agent 产品，后来也在往更通用的助手能力扩展。名字若让人先入为主，后续理解成本会高很多。
+
+OpenClaw 之类产品引起关注，往往也不只是因为又发明了新协议，而更因为：
+
+* 降低了配置门槛；
+* 能接入社交软件、配置定时任务；
+* 有页面可以看到并管理 Skill；
+* 第一次让普通人觉得「这像一个助手」，而不只是电脑里的后台服务。
+
+这也回到一个更朴素的判断：**便利性常常比概念纯度更决定扩散速度。**
 
 
-# 两套容易混的机制：Function Calling 与 MCP
+# 稳定流程别每次都让 Agent 自由发挥
 
-这是最常见的混淆点之一。两者都会出现在「调工具」链路里，但解决的不是同一段问题。
+开放 Agent 很强，但有个统一缺点：对相对稳定的多阶段任务，每次都让它重新规划，既不稳定，也浪费 Token。
 
-## Function Calling / Tool Calling
+举个典型例子：
 
-面向 **宿主程序 ↔ LLM**：
+1. 从英文 PDF 提取文本；
+2. 翻译成中文；
+3. 保存为 Markdown。
 
-* 目标：让模型在需要外部能力时，输出**可解析的结构化工具请求**（名称 + 参数），而不是只吐一段自由文本；
-* 关键事实：模型**并不直接执行**函数；真正执行的是宿主程序，执行完再把结果作为后续上下文喂回模型；
-* 现在也常统称 **Tool Calling**；各家 API 字段名不同，但模式相近。
+其中「提取 PDF」「保存文件」完全可以固化成脚本；只有中间翻译更适合交给模型。整条链路未必需要每一步都由智能体重新发明。
 
-没有这类机制，宿主就得靠脆弱的自然语言解析去猜模型意图，工程上很难做稳。
+于是出现了不同固化方式：
 
-## MCP（Model Context Protocol）
+## 1. 确定性编排（代码 / Chain）
 
-面向 **AI 应用如何标准地接入外部能力**：
+用代码把步骤写死，或用链式编排框架把流程固定下来。优点是稳定、可测、可复现；缺点是输入输出一组合爆炸，维护成本会很快上升。
 
-* 常见架构是 **Host（宿主应用）— Client（连接层）— Server（能力提供方）**；
-* Server 可暴露的不只是工具，还包括：
-  * **Tools**：可执行动作（查库、调 API、改文件等）；
-  * **Resources**：可读的上下文数据源；
-  * **Prompts**：可复用的提示模板；
-* 工具相关协议动作里，`tools/list`、`tools/call` 是最常被提到的一对；通信通常基于 JSON-RPC。
+> **NOTE：**  
+> LangChain 早期的确以 Chain 著称，所以视频里常拿它举例；但今天它已不只是硬编码链条，也提供 Agent 等能力。和 LangGraph 的分工，更接近「组件/harness」与「复杂状态图编排」。谱系最左端，准确说法应是**确定性编排**。
 
-当能力还写死在同一个进程里时，未必需要独立协议；一旦希望「一份能力被多个 AI 应用复用、动态发现」，就更需要 MCP 这类标准接口。
+## 2. Workflow / 工作流
 
-## 为什么不能互相取代
+把编程换成低代码拖拽。对非程序员更友好，改流程也直观，但本质仍偏「程序预先规定走向」。分支一多，画布一样会复杂。
+
+## 3. 为什么会逼出 Skill
+
+如果输入可能是 PDF / Word / TXT / PPT，输出可能是 Markdown / HTML / 图片，难道每一种排列组合都画一套工作流？可以堆很多 if-else，但若仍希望用户用自然语言触发，分支判断又会重新变得困难。
+
+更折中的做法是：
+
+1. 准备一个目录，放好可能用到的转换脚本；
+2. 写一份统一说明，把流程和选择规则讲清楚；
+3. 让 Agent 先读说明，再按文件类型灵活选脚本执行。
+
+为了避免每次都人工追加「请先读那份说明」，宿主程序可以约定：启动或接到任务时，自动去指定位置读取 `SKILL.md`。于是就有了今天常说的 **Skill**。
+
+## 4. Skill 到底是什么
+
+更贴近当前常见实现的理解是：
+
+* Skill 通常是一个目录，核心是 `SKILL.md`，并可附带参考文档、脚本等资源；
+* 关键设计是 **progressive disclosure（渐进式披露）**：先只暴露名称/描述，相关时再加载全文，需要时再读附加文件或执行脚本；
+* 触发方式通常是模型自主判断是否调用，而不是每次由人整份粘贴进 Prompt。
+
+所以，把 Skill 仅仅说成「换地方存的提示词」偏简化了；它更像「可被发现、按需加载的专项能力包」。相对纯硬编码，多了灵活；相对完全放养的 Agent，又多了边界。
+
+
+# SubAgent：把上下文隔离开
+
+复杂任务里，主会话很容易被中间过程撑爆。于是又出现 **SubAgent**：
+
+* 把相对独立的子任务丢给子代理；
+* 子过程细节不全部回流主会话；
+* 主 Agent 主要回收结论和必要产物。
+
+本质先看做 **任务拆分 + 上下文隔离**，不必先上升成「多智能体社会」。
+
+
+# 一张生长图：名词是怎么叠出来的
+
+把前面路径收成一张图，大致是这样：
+
+<div class="mermaid" style="display: flex; justify-content: center; width: 100%; margin: 0 auto;">
+flowchart BT
+    classDef base fill:#ECEFF1,stroke:#455A64,color:#222
+    classDef agent fill:#E3F2FD,stroke:#1565C0,color:#222
+    classDef product fill:#FFF3E0,stroke:#EF6C00,color:#222
+
+    P1["① LLM<br/>大语言模型 / 自回归生成"] --> P2["② Prompt<br/>送入模型的输入"]
+    P2 --> P3["③ Context Window<br/>有限上下文窗口"]
+    P3 --> P4["④ Memory<br/>靠回填历史维持连续性"]
+    P4 --> P5["⑤ Agent<br/>模型 + harness 循环调工具"]
+    P5 --> P6["⑥ RAG / Web Search<br/>获取参数外信息"]
+    P5 --> P7["⑦ Function Calling<br/>模型提出结构化工具请求"]
+    P5 --> P8["⑧ MCP<br/>宿主与外部能力的标准协议"]
+    P5 --> P9["⑨ 确定性编排 / Workflow / Skill<br/>多步任务如何固化"]
+    P5 --> P10["⑩ SubAgent<br/>子任务与上下文隔离"]
+    P5 --> P11["⑪ 产品形态<br/>CLI / IDE / OpenClaw"]
+
+    class P1,P2,P3,P4 base
+    class P5,P6,P7,P8,P9,P10 agent
+    class P11 product
+</div>
+
+<p align="center"><em>图 2：从 LLM 往上叠出来的概念层</em></p>
+
+
+# 两个经典混淆题
+
+每个新词出来时，都会带一波「A 会不会取代 B」的讨论。其中两个最值得先拆开。
+
+## 1. Function Calling 和 MCP 有什么关系？
 
 | | Function Calling / Tool Calling | MCP |
 |---|---|---|
 | 主要连接 | 宿主与模型 | 宿主与外部能力服务 |
 | 解决什么 | 模型如何提出/选择工具调用 | 外部能力如何被发现、描述与调用 |
 | 典型形态 | API 响应里的结构化 tool call | Host/Client/Server + tools/resources/prompts |
-| 是否同层 | 否 | 否 |
 
-更准确的关系往往是：**MCP 负责把外部工具变成宿主可管理的能力；Function Calling 负责让模型以结构化方式请求这些能力。**  
-所以「MCP 会不会取代 Function Calling」本身有点错位——它们常是协作，而不是二选一。
-
-
-# 流程如何固化：从确定性编排到自由 Agent
-
-现实任务很少是单轮问答。比如：从英文 PDF 抽文本 → 翻译成中文 → 存成 Markdown。这类多阶段流程，至少有四种常见落法。
-
-<div class="mermaid" style="display: flex; justify-content: center; width: 100%; margin: 0 auto;">
-flowchart LR
-    classDef rigid fill:#FFCDD2,stroke:#C62828,color:#222
-    classDef mid fill:#FFE0B2,stroke:#EF6C00,color:#222
-    classDef soft fill:#C8E6C9,stroke:#2E7D32,color:#222
-    classDef flex fill:#BBDEFB,stroke:#1565C0,color:#222
-
-    LC["确定性编排<br/>代码/Chain 写死步骤<br/>最稳定 / 难包容变化"] -->|"更柔性"| WF["Workflow<br/>低代码拖拽<br/>好改一点 / 仍偏程序控"]
-    WF -->|"更柔性"| SK["Skill<br/>SKILL.md + 资源/脚本<br/>模型按需加载 / 有约束"]
-    SK -->|"更柔性"| PA["开放 Agent 循环<br/>动态拆解与自写脚本<br/>最灵活 / 易失控"]
-
-    class LC rigid
-    class WF mid
-    class SK soft
-    class PA flex
-</div>
-
-<p align="center"><em>图 3：确定性编排 → Workflow → Skill → 开放 Agent，刚性递减、柔性递增</em></p>
-
-## 1. 确定性编排（常以代码 / Chain 实现）
-
-用代码或链式编排把步骤写死。优点是稳定、可测、可复现；缺点是对输入输出组合爆炸不友好——PDF/Word/TXT 进、Markdown/HTML/图片出，若每一种组合都手写链路，维护成本会很快上升。
-
-> **NOTE：**  
-> LangChain 早期的确以 Chain 著称，但今天它已不只是「硬编码链条」框架，也提供 Agent、工具抽象等能力；和 LangGraph 的分工更接近「组件/harness」与「复杂状态图编排」。因此谱系最左端，更准确的说法是**确定性编排**，而不是把整个 LangChain 等同于最僵硬的那一端。
-
-## 2. Workflow / 工作流
-
-把步骤编排换成低代码/可视化拖拽（各类工作流产品都属于这一层）。对非程序员更友好，改流程也直观一些，但本质仍偏「程序预先规定走向」：分支一多，画布一样会复杂。
-
-## 3. Skill（Agent Skills）
-
-更贴近当前常见实现的理解是：
-
-* Skill 通常是一个目录，核心文件是 `SKILL.md`（含元数据与操作说明），并可附带参考文档、脚本等资源；
-* 设计关键是 **progressive disclosure（渐进式披露）**：启动时往往只加载名称/描述；真正相关时再读完整说明；需要时才继续加载附加文件或执行脚本；
-* 触发方式通常是**模型自主判断是否调用**，而不是每次都由人把整份说明书粘进 Prompt。
-
-因此，把 Skill 仅仅说成「换个地方存的提示词」偏简化了；它更像「可被发现、按需加载的专项能力包」。相对纯硬编码，多了灵活空间；相对完全放养的 Agent，又多了文档与脚本边界。
-
-> **NOTE：**  
-> Skill 和 MCP 也不是同一维度。Skill 组织的是给 Agent 用的程序性知识与本地资源；MCP 组织的是应用与外部能力服务之间的协议。可以把工具用法写进 Skill，从而在部分场景减少对独立 MCP Server 的依赖，但这不等于两者可以划等号。Skill 更适合拿去和「确定性编排 / Workflow / 开放 Agent」比较。
-
-## 4. 开放 Agent 循环
-
-把目标直接丢给 Agent，让它在工具循环里自己拆步骤、选工具，必要时自己写脚本再执行。柔性最高，也通常更贵、更不稳定：Token 消耗大，过程不可控，简单任务被复杂化的风险也更高。
-
-可用一句话记住这条谱系：
+更准确的关系是：
 
 ~~~
-越靠左，越稳、越死；
-越靠右，越活、越飘。
-选型的关键不是谁更新，而是任务有多稳定、能允许多少不确定性。
+MCP 负责把外部能力变成宿主可管理的接口；
+Function Calling 负责让模型以结构化方式请求这些能力。
+二者常协作，而不是互相取代。
 ~~~
 
+## 2. Skill 和 MCP 有什么区别？
 
-# SubAgent：不是更多智能，而是任务与上下文隔离
+Skill 更像给 Agent 用的程序性知识包；MCP 更像应用与外部能力服务之间的协议。可以把工具用法写进 Skill，从而在部分场景减少对独立 MCP Server 的依赖，但这不等于两者同层。
 
-复杂任务里，主会话上下文很容易被中间过程撑爆。SubAgent 的常见动机很务实：
-
-* 把相对独立的子任务交给子代理执行（可串行，也可并行）；
-* 子过程产生的细节上下文，不全部回流主会话；
-* 主 Agent 主要回收结论、状态或必要产物。
-
-因此，SubAgent 首先是 **任务拆分 + 上下文隔离** 的组织方式，不必一上来就理解成「更高级的多智能体社会」。
-
-
-# 一张图看清运行时在干什么
-
-把上面几层合在一起，一次典型调用更像这样：
-
-<div class="mermaid" style="display: flex; justify-content: center; width: 100%; margin: 0 auto;">
-flowchart LR
-    classDef user fill:#FFF3E0,stroke:#E65100,color:#222
-    classDef host fill:#E3F2FD,stroke:#1565C0,color:#222
-    classDef model fill:#F3E5F5,stroke:#6A1B9A,color:#222
-    classDef tool fill:#FFF8E1,stroke:#F9A825,color:#222
-
-    U["人"] -->|"自然语言"| H["Host / Harness"]
-    H -->|"组装 Prompt<br/>Memory / RAG / Skill"| L["LLM"]
-    L -->|"Tool Calling<br/>结构化工具请求"| H
-    H -->|"本地工具或 MCP call"| T["Tools / Servers"]
-    T -->|"结果回填上下文"| H
-    H -->|"最终答复"| U
-
-    class U user
-    class H host
-    class L model
-    class T tool
-</div>
-
-<p align="center"><em>图 4：人 → Host → LLM / Tools → 回填上下文 → 最终答复</em></p>
-
-对应到职责划分：
-
-1. **模糊分流**交给模型：用户到底想做 A 还是 B，需要语义理解与决策；
-2. **确定逻辑**交给程序：例如 PDF 文本提取、文件保存、格式转换、真正执行工具；
-3. Host / Harness 负责把两者粘成循环，并尽量减少人与模型的无效往返。
-
-
-# 易混概念对照
+也正因此，Skill 更应该拿去和「确定性编排 / Workflow / 开放 Agent」比，而不是硬跟 MCP 比高低。
 
 <div class="mermaid" style="display: flex; justify-content: center; width: 100%; margin: 0 auto;">
 flowchart TB
@@ -330,34 +360,97 @@ flowchart TB
     class X1,X2 ok
 </div>
 
-<p align="center"><em>图 5：Function Calling vs MCP；Skill vs MCP</em></p>
-
-再补一张简表：
-
-| 对比 | 结论 |
-|---|---|
-| Function Calling vs MCP | 不同接口层；前者连模型，后者连外部能力，常配合使用 |
-| Skill vs MCP | 不同问题域；Skill 是能力包/程序性知识，MCP 是接入协议 |
-| Skill vs Workflow / 确定性编排 | 同属「多步任务如何固化」，可比 |
-| Agent vs LLM | Agent ≈ 模型 + harness 的工具体循环；LLM 是其中的生成与决策引擎 |
-| Memory vs 模型参数记忆 | 产品 Memory 多指上下文/外置状态管理，不等于参数内知识 |
+<p align="center"><em>图 3：Function Calling vs MCP；Skill vs MCP</em></p>
 
 
-# 产品形态为什么突然重要
+# 流程固化谱系：从刚到柔
 
-同一套 Agent 能力，可以长成完全不同的产品体验：
+如果把多阶段任务的实现方式排成一条谱系，可以这样看：
 
-* 命令行 CLI；
-* 编程 IDE 内的编码助手；
-* 接入社交软件、带定时任务与 Skill 管理页的桌面助手。
+<div class="mermaid" style="display: flex; justify-content: center; width: 100%; margin: 0 auto;">
+flowchart LR
+    classDef rigid fill:#FFCDD2,stroke:#C62828,color:#222
+    classDef mid fill:#FFE0B2,stroke:#EF6C00,color:#222
+    classDef soft fill:#C8E6C9,stroke:#2E7D32,color:#222
+    classDef flex fill:#BBDEFB,stroke:#1565C0,color:#222
 
-最近 CloudBot / OpenClaw 一类产品引起关注，并不一定因为底层出现了全新智能原理，而往往因为：
+    LC["确定性编排<br/>代码/Chain 写死步骤<br/>最稳定 / 难包容变化"] -->|"更柔性"| WF["Workflow<br/>低代码拖拽<br/>好改一点 / 仍偏程序控"]
+    WF -->|"更柔性"| SK["Skill<br/>SKILL.md + 资源/脚本<br/>模型按需加载 / 有约束"]
+    SK -->|"更柔性"| PA["开放 Agent 循环<br/>动态拆解与自写脚本<br/>最灵活 / 易失控"]
 
-* 降低了配置门槛；
-* 把 Agent 从「电脑里的后台服务」变成「能被普通人感知和操作的助手」；
-* 在社交通道、定时任务、Skill 管理等处补齐了使用闭环。
+    class LC rigid
+    class WF mid
+    class SK soft
+    class PA flex
+</div>
 
-这也回到一个更朴素的判断：**便利性常常比概念纯度更决定扩散速度**。对普通用户而言，让他去手动安放 Skill 目录、配置 MCP、填写各类 API Key，本身就是很高的摩擦。
+<p align="center"><em>图 4：确定性编排 → Workflow → Skill → 开放 Agent</em></p>
+
+* **确定性编排**：全程硬编码，稳，但难包容变化。  
+* **Workflow**：把程序控制换成拖拽，改起来容易些，仍偏预定路径。  
+* **Skill**：流程走向更多由模型根据说明与脚本自行选择，既保留灵活性，又不会完全失控。  
+* **开放 Agent**：最柔，可随时改计划甚至自写脚本；也最容易把简单任务做复杂，并烧掉大量 Token。
+
+一句话记：
+
+~~~
+越靠左，越稳、越死；
+越靠右，越活、越飘。
+选型关键不是谁更新，而是任务有多稳定、能允许多少不确定性。
+~~~
+
+至于 Skill 的渐进式披露、按需加载，是它很重要的特性；但当 Token 显著变便宜后，这类「省上下文」的优化权重可能会变化。对普通人来说，Skill 眼下吸引人的地方，往往是它同时摸到了灵活与可控两边。
+
+
+# 再往下看一层本质
+
+把这些技术继续抽象，其实大多没有离开两件事：
+
+1. **自动往提示词里增加上下文**  
+   Search、RAG、Memory、Skill 文档，常常都是在做这件事。
+2. **用程序代理，减少人与模型的无效往返**  
+   能脚本化的就别每次重新问模型；模糊分流才交给模型。
+
+这也是为什么可以说：
+
+~~~
+一个流程里，所有能用固定程序解决、不必询问大模型的地方，
+往往正是 Agent / Harness 最该发挥作用的地方：
+模糊分流交给模型，确定逻辑交给程序。
+~~~
+
+运行时闭环可以画成：
+
+<div class="mermaid" style="display: flex; justify-content: center; width: 100%; margin: 0 auto;">
+flowchart LR
+    classDef user fill:#FFF3E0,stroke:#E65100,color:#222
+    classDef host fill:#E3F2FD,stroke:#1565C0,color:#222
+    classDef model fill:#F3E5F5,stroke:#6A1B9A,color:#222
+    classDef tool fill:#FFF8E1,stroke:#F9A825,color:#222
+
+    U["人"] -->|"自然语言"| H["Host / Harness"]
+    H -->|"组装 Prompt<br/>Memory / RAG / Skill"| L["LLM"]
+    L -->|"Tool Calling<br/>结构化工具请求"| H
+    H -->|"本地工具或 MCP call"| T["Tools / Servers"]
+    T -->|"结果回填上下文"| H
+    H -->|"最终答复"| U
+
+    class U user
+    class H host
+    class L model
+    class T tool
+</div>
+
+<p align="center"><em>图 5：人 → Host → LLM / Tools → 回填上下文 → 最终答复</em></p>
+
+
+# Token 成本，以及为什么「好用」会赢
+
+现在还有一个现实约束：Token 很贵。Agent 越能自己默默把事情办完，背后通常也消耗越多。未来若本地可部署的强模型更普及，Token 成本下降，很多今天看起来「 intermediate / 略鸡肋」的折中方案，权重都可能重排。
+
+但即便成本下降，产品层面仍可能遵循一个老规律：便利性优先。Java 里的 Spring Boot、Python 里的 `uv`，都在提醒同一件事——开发者尚且怕麻烦，面向普通人的 Agent 更不可能要求人人去手搓目录、配置 MCP、填写一堆 API Key。
+
+因此，未来更可能出现的，不是让用户理解更多名词，而是一个打包好的超级助手：常用能力预置完毕，名字也许都不叫今天的 MCP / Skill，但普通人打开就能用。
 
 
 # 小结
@@ -365,9 +458,10 @@ flowchart TB
 如果只保留几句自己用的判断：
 
 1. **LLM** 是生成与决策引擎；**Agent** 通常是「模型 + harness」在工具循环里完成任务。  
-2. **Prompt / Context Window / Memory / RAG / Skill**，很多时候都在解决同一类问题：把正确信息，在正确时机放进有限上下文。  
+2. **Prompt / Context / Memory / RAG / Skill**，很多时候都在解决同一类问题：把正确信息，在正确时机放进有限上下文。  
 3. **Function Calling** 让模型结构化地提出工具请求；**MCP** 让宿主标准地发现和接入外部能力；二者常协作。  
 4. **确定性编排 → Workflow → Skill → 开放 Agent**，是稳定性与灵活性的连续谱，不是简单的新旧取代。  
-5. 选型先问任务稳不稳、错了代价大不大，再问该不该上更新的名词。
+5. 很多新词是技术发展的中间产物；真正持久的，是「省人时间、降低门槛」的方向。  
+6. 选型先问任务稳不稳、错了代价大不大，再问该不该上更新的名词。
 
-后续如果继续写实践向笔记，会更适合落到具体系统（例如 OpenClaw 的 Skill 组织、MCP 接入，或 LangGraph 的状态图编排）上，把这篇的概念地图逐项对上代码与配置。
+后续若继续写实践笔记，会更适合落到具体系统上，例如 OpenClaw 的 Skill 组织与 MCP 接入，或 LangGraph 的状态图编排，把这篇的概念地图逐项对上代码与配置。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 改动说明

重写 `_posts/2026-08-01-Agent基本概念梳理.md`，把参考视频中的完整脉络尽量整合进博文，同时改写润色，避免照抄口播原文。

## 主要变化

- 按「问题如何一步步长出来」叙事重组：LLM → Prompt/Memory → Agent → RAG → Function Calling → MCP → 产品形态 → Skill/Workflow 谱系
- 补入视频中关键论证：一问一答约束、假多轮、Agent 作为确定逻辑承载、PDF 翻译固化例子、Skill 为何被逼出来、Token/便利性趋势等
- 保留此前已核校的术语准确性，以及彩色 Mermaid、全宽图、居中图题
- 文首仍标注视频参考

请审阅合并；合并后我会删除临时分支 `cursor-agent`。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-35a68d79-a791-4f54-9a0b-f17e48c90cbe?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35a68d79-a791-4f54-9a0b-f17e48c90cbe&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

