### PR TITLE
收窄左侧栏并放大地球占比

### DIFF
--- a/style.scss
+++ b/style.scss
@@ -319,7 +319,7 @@ img {
 //
 
 .wrapper-sidebar {
-  width: 30%;
+  width: 25%;
 	-webkit-background-size: cover;
 	background-size: cover;
 	background-color: $background-color;
@@ -377,7 +377,7 @@ img {
     }
 
     &.sidebar-globe {
-      width: 70%;
+      width: 85%;
       margin: 0 auto 4px;
 
       .globe-wrap {
@@ -532,7 +532,7 @@ nav {
 
 .wrapper-content {
   float: right;
-  width: 70%;
+  width: 75%;
 
   @include mobile {
     float: none;
@@ -622,7 +622,7 @@ nav {
 .toc {
   width: 240px;
   height: 100%;
-  left: 30%;
+  left: 25%;
   position: fixed;
   z-index: 4;
   padding: 60px 20px 0 20px;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
调整首页左右栏比例与侧栏地球大小：

- `.wrapper-sidebar`：`30%` → `25%`
- `.wrapper-content`：`70%` → `75%`
- `.toc` 的 `left`：`30%` → `25%`（与侧栏对齐）
- `.sidebar-globe`：`70%` → `85%`

修改文件：`style.scss`。合入后可删临时分支 `cursor-agent`。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-35a68d79-a791-4f54-9a0b-f17e48c90cbe?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35a68d79-a791-4f54-9a0b-f17e48c90cbe&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

