### PR TITLE
收紧目录与正文之间的间距

### DIFF
--- a/style.scss
+++ b/style.scss
@@ -647,8 +647,14 @@ nav {
 }
 
 @media screen and (max-width:6600px) and (min-width:1200px){
+  // 有目录时：为固定 TOC 留位，并取消 .container 水平居中，避免目录与正文之间出现大块空白
   .withtoc{
-    padding-left: 260px;
+    padding-left: 220px;
+
+    .container {
+      margin-left: 0;
+      margin-right: auto;
+    }
   }
 
   /* 仅添加滚动条功能，不改变布局 */

--- a/style.scss
+++ b/style.scss
@@ -27,9 +27,14 @@ body {
 
 .container {
   margin: 0 auto;
-  max-width: 1280px; // 无目录时正文可更充分利用右侧区域；有目录时配合 .withtoc 靠左排布
-  padding: 0 28px;
+  max-width: 1560px; // 有目录时上限；无目录见下方 :not(.withtoc)
+  padding: 0 36px;
   width: 100%;
+}
+
+// 无目录时：正文铺满右侧内容区，只保留两侧内边距
+.wrapper-content:not(.withtoc) > .container {
+  max-width: none;
 }
 
 h1, h2, h3, h4, h5, h6 {

--- a/style.scss
+++ b/style.scss
@@ -27,8 +27,8 @@ body {
 
 .container {
   margin: 0 auto;
-  max-width: 1000px;
-  padding: 0 20px;
+  max-width: 1280px; // 无目录时正文可更充分利用右侧区域；有目录时配合 .withtoc 靠左排布
+  padding: 0 28px;
   width: 100%;
 }
 
@@ -620,12 +620,12 @@ nav {
 // TOC(目录样式)
 
 .toc {
-  width: 240px;
+  width: 200px;
   height: 100%;
   left: 25%;
   position: fixed;
   z-index: 4;
-  padding: 60px 20px 0 20px;
+  padding: 60px 12px 0 12px;
   
   &:before{
     content:"目录";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
调整文章页排版：收紧目录与正文间距，并加宽无目录时的正文区域。

## 原因
1. 有目录时：`.container` 仍 `margin: 0 auto` 居中，宽屏下目录右侧会空一大块。
2. 无目录时：`.container` 的 `max-width` 偏窄，右侧栏里左右留白过大。

## 改动（`style.scss`）
- `.withtoc .container`：靠左（`margin-left: 0`）
- `.withtoc` 的 `padding-left`：`260px` → `220px`
- `.toc` 宽度：`240px` → `200px`
- `.container` 的 `max-width`：`1000px` → `1560px`
- **无目录**：`.wrapper-content:not(.withtoc) > .container` 取消 `max-width`，正文铺满右侧 75% 内容区（两侧保留 `36px` 内边距）

合入后可删临时分支 `cursor-agent`。若还想再留白/再贴边，主要改 `.container` 的 `padding` 即可。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-35a68d79-a791-4f54-9a0b-f17e48c90cbe?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35a68d79-a791-4f54-9a0b-f17e48c90cbe&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

