### PR TITLE
用视口百分比控制正文宽度与两侧留白

### DIFF
--- a/style.scss
+++ b/style.scss
@@ -27,7 +27,7 @@ body {
 
 .container {
   margin: 0 auto;
-  max-width: 56vw; // 正文宽度约为屏幕的 56%，两侧自然留白
+  max-width: 60vw; // 正文宽度约为屏幕的 60%，两侧自然留白
   padding: 0 3vw;  // 两侧内边距各约屏幕的 3%
   width: 100%;
 

--- a/style.scss
+++ b/style.scss
@@ -27,14 +27,14 @@ body {
 
 .container {
   margin: 0 auto;
-  max-width: 1560px; // 有目录时上限；无目录见下方 :not(.withtoc)
-  padding: 0 36px;
+  max-width: 56vw; // 正文宽度约为屏幕的 56%，两侧自然留白
+  padding: 0 3vw;  // 两侧内边距各约屏幕的 3%
   width: 100%;
-}
 
-// 无目录时：正文铺满右侧内容区，只保留两侧内边距
-.wrapper-content:not(.withtoc) > .container {
-  max-width: none;
+  @include mobile {
+    max-width: 100%;
+    padding: 0 20px;
+  }
 }
 
 h1, h2, h3, h4, h5, h6 {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
上一版无目录正文铺满后偏宽，现改回更易读的宽度，并用屏幕百分比控制。

## 改动（`style.scss`）
- `.container`：`max-width: 60vw`（正文约屏幕 60%）
- 两侧内边距：`padding: 0 3vw`（各约屏幕 3%）
- 去掉无目录 `max-width: none` 铺满逻辑
- 窄屏（≤1200px）：仍 `max-width: 100%`、`padding: 0 20px`

有目录页继续靠左；无目录页居中，两侧留白随屏幕缩放。

合入后可删临时分支 `cursor-agent`。若还想再宽/再窄，主要改 `60vw` / `3vw` 即可。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-35a68d79-a791-4f54-9a0b-f17e48c90cbe?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35a68d79-a791-4f54-9a0b-f17e48c90cbe&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

