### PR TITLE
显存估算博文：补充算力评估并扩展 GPU 对照表

### DIFF
--- a/_posts/2026-08-11-大模型参数量与显存估算.md
+++ b/_posts/2026-08-11-大模型参数量与显存估算.md
@@ -18,7 +18,7 @@ excerpt: ""
 
 看到一个新模型发布，最常问的问题往往不是「它有多强」，而是：**我这台机器的显存够不够跑**。名字里的 `7B`、`70B`、`236B` 给出了规模量级，但真正决定显存的，是**参数个数 × 每个参数占多少字节**，再叠加推理时的上下文缓存与系统开销。
 
-本文整理一条可复用的估算路径：先分清参数量含义，再看常见精度对应的字节数与格式差异，最后落到一个好记的公式，并说明为何实际占用通常高于「权重本身」。
+本文整理一条可复用的估算路径：先分清参数量含义，再看常见精度对应的字节数与格式差异，落到一个好记的公式并说明运行时余量；最后对照常见 GPU 的显存 / 带宽 / 算力，并说明 TFLOPS、PFLOPS、TOPS 这类数字该怎么读。
 
 先给一个直觉对照：
 
@@ -157,44 +157,71 @@ $$
 
 ---
 
-# 六、常见 GPU 显存与带宽一览
+# 六、AI 算力单位怎么评估
 
-估完模型需求后，还要对照本机「标称显存」；若关心吞吐，再看**显存带宽**（单位时间内 GPU 与显存之间能搬多少数据）。容量决定「能不能装下」，带宽更影响「算得有多顺」——权重与 KV Cache 都要反复读，带宽不足时延迟与利用率会先顶上去。
+显存回答「装不装得下」；规格表上的 TFLOPS / PFLOPS / TOPS 回答「理论上算得有多快」。同一张卡常被报出好几个差很多的数字——差别通常不在硬件本身，而在**统计口径**。读算力时，建议固定问清下面几层。
 
-下表按 NVIDIA 官网产品页 / 规格表 / 架构白皮书整理（数据中心卡取单卡 **GPU Memory / Memory Bandwidth**；专业卡同；GeForce 容量与 50 系带宽见 [Compare GeForce Graphics Cards](https://www.nvidia.com/en-us/geforce/graphics-cards/compare/)，4090 / 3090 带宽分别见 [Ada](https://images.nvidia.com/aem-dam/Solutions/geforce/ada/nvidia-ada-gpu-architecture.pdf) / [Ampere GA102](https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.pdf) 白皮书）。此处只列对照大模型时常看的几款。
+**先分清两套单位。** FLOPS（Floating Point Operations Per Second）量的是浮点运算吞吐，常见于 FP64 / FP32 / TF32 / FP16 / BF16 / FP8 / FP4；TOPS（Tera Operations Per Second）量的是整数运算吞吐，常见于 INT8 / INT4。进制上 $1\,\mathrm{PFLOPS} = 1000\,\mathrm{TFLOPS} = 10^{15}\,\mathrm{FLOPS}$，把 TFLOPS 填成 PFLOPS 时除以 1000 即可，这与精度无关。FLOPS 与 TOPS **不能互相换算，也不能相加**：即便 FP8 的 PFLOPS 与 INT8 的 TOPS 数字碰巧接近，也只是同为 8bit 位宽时吞吐「看起来像」，背后仍是两套数制与电路。
 
-| 类别 | 型号 | 标称显存 | 显存带宽 | 显存类型 |
-| --- | --- | --- | --- | --- |
-| 数据中心 | [NVIDIA H200](https://www.nvidia.com/en-us/data-center/h200/) | 141 GB | 4.8 TB/s | HBM3e |
-| 数据中心 | [NVIDIA H800](https://docs.nvidia.com/ai-enterprise/release-8/latest/infra-software/vgpu/reference/hopper.html) | 80 GB / 94 GB（NVL） | 约 3.35 TB/s（SXM）/ 约 3.9 TB/s（NVL） | HBM3 |
-| 数据中心 | [NVIDIA H100](https://www.nvidia.com/en-us/data-center/h100/) | 80 GB（SXM）/ 94 GB（NVL） | 3.35 TB/s（SXM）/ 3.9 TB/s（NVL） | HBM3 |
-| 数据中心 | [NVIDIA A100](https://www.nvidia.com/en-us/data-center/a100/) | 40 GB / 80 GB | 1.555 TB/s（40GB）；1.935～2.039 TB/s（80GB PCIe / SXM） | HBM2 / HBM2e |
-| 专业卡 | [NVIDIA RTX PRO 6000 Blackwell](https://www.nvidia.com/en-us/products/workstations/professional-desktop-gpus/rtx-pro-6000/) | 96 GB | 1792 GB/s | GDDR7（ECC） |
-| 专业卡 | [NVIDIA RTX PRO 5000 Blackwell](https://www.nvidia.com/en-us/products/workstations/professional-desktop-gpus/rtx-pro-5000/) | 48 GB / 72 GB | 1344 GB/s | GDDR7（ECC） |
-| GeForce | GeForce RTX 5090 | 32 GB | 1792 GB/s | GDDR7 |
-| GeForce | GeForce RTX 4090 | 24 GB | 1008 GB/s（约 1 TB/s） | GDDR6X |
-| GeForce | GeForce RTX 3090 | 24 GB | 936 GB/s | GDDR6X |
+**再对齐精度，再比大小。** 同一套 Tensor Core 在不同精度模式下会给出不同峰值：位宽越低，单位时间能塞进的操作通常越多，账面数字越高。因此 FP16、FP8、FP4 的峰值本来就不是同一个指标；跨代、跨卡比较时，必须先固定「这是 BF16 还是 FP8」。也正因为如此，集群备案、算力普查里更常用 **BF16/FP16 稠密口径**——它仍是训练侧共识最高、最少被「换精度刷数字」带偏的基准；FP8/INT8/FP4 更适合作为部署档位，而不是唯一对标尺。
 
-结合前文口诀，可以很快建立量级直觉（仍要再留 KV Cache 与系统余量）：
+**还要看稠密还是稀疏。** Ampere 之后常见的 2:4 结构化稀疏，理想情况下可把 Tensor Core 峰值再抬约一倍。规格表若标注 sparse / with sparsity，写的往往是这条「更好看」的曲线；多数生产模型并未严格按 2:4 稀疏部署，实际很难摸到稀疏峰值。同一款 H100，有人写约 0.99 PFLOPS（BF16 稠密）、有人写约 1.98 PFLOPS，两者都可能「对」，只是一个稠密、一个稀疏。
 
-* **24 GB / ~0.9–1.0 TB/s**（3090 / 4090）：半精度约 7B～13B 较常见；INT4 下约 70B（口诀约 35 GB）单卡仍吃紧。两者容量相同，4090 带宽略高。
-* **32 GB / 1.79 TB/s**（5090）：容量与带宽都比 4090 宽一档，仍远不够半精度 70B（约 140 GB）。
-* **48～96 GB / 1.3–1.8 TB/s**（RTX PRO 5000 / 6000）：桌面专业卡容量更高；带宽与旗舰 GeForce 同量级，量化后的大模型或更长上下文更现实。
-* **80～141 GB / 约 2–4.8 TB/s**（A100 / H100 / H800 / H200）：数据中心常见档位；HBM 带宽明显高于桌面 GDDR，更利于大模型吞吐。半精度 70B 仍要看是否多卡或量化，H200 的 141 GB + 4.8 TB/s 对单卡大模型更友好。
+**峰值不是「可加总的总算力」。** 一张卡在 FP16、FP8、FP4、INT8 下的多个数字，描述的是同一硬件切换工作模式后的峰值，不是几路独立算力。把它们加总成「总 PFLOPS」没有意义。
+
+**理论峰值之外，还要看带宽与 MFU。** Roofline 视角里，运算强度（总浮点运算 ÷ 搬运字节）高则更偏算力受限，低则更偏带宽受限。大模型逐 token 生成常常是后者：算力数字再高，也会先卡在显存带宽。经验上，训练更同时吃算力与显存容量；小 batch 推理则经常先看带宽。厂商公布的是理想峰值；真实训练可用
+
+$$
+\mathrm{MFU} = \frac{\text{实际有效 FLOPS}}{\text{硬件理论峰值 FLOPS}}
+$$
+
+衡量。头部大模型训练里 MFU 到约 40% 已算工程上很强，许多项目只有约 20%——通信、算子、batch/序列长度、数据加载都会把峰值「打折」。`nvidia-smi` 的 GPU-Util 只表示「采样期内有没有 kernel 在跑」，并不等于 Tensor Core 吃满，更不是 MFU；要回答「PFLOPS 用出来多少」，仍需结合 profiler / DCGM 与业务侧计量。
 
 > **NOTE：**  
-> 同型号常有多种形态（如 A100 40/80 GB、H100 SXM/NVL、RTX PRO 5000 的 48/72 GB）。表中「/」表示官网并列的配置；对照时以实际机器规格为准。H800 为面向特定市场的 Hopper 产品线，显存容量与常见带宽档位与同形态 H100 对齐（差异主要在 NVLink 等互联规格）；上表 H800 带宽按与 H100 同形态对照填写。
+> 看到任何一个算力数字，先核对四件事：浮点还是整数、哪个精度、稠密还是稀疏、理论峰值还是实测。口径没对齐时，横向比较没有信息量。
 
 ---
 
-# 七、怎么用这套算法做判断
+# 七、常见 GPU 显存、带宽与算力一览
+
+估完模型需求后，还要对照本机「标称显存」；若关心吞吐，再看**显存带宽**与**算力峰值**。容量决定「能不能装下」，带宽更影响「算得有多顺」，算力则要在对齐精度与稠密/稀疏口径后再比。
+
+下表按 NVIDIA 官网产品页 / 规格表 / 架构白皮书整理（数据中心卡取单卡 **GPU Memory / Memory Bandwidth** 与稠密 Tensor Core 峰值；专业卡同；GeForce 容量与 50 系带宽见 [Compare GeForce Graphics Cards](https://www.nvidia.com/en-us/geforce/graphics-cards/compare/)，4090 / 3090 带宽分别见 [Ada](https://images.nvidia.com/aem-dam/Solutions/geforce/ada/nvidia-ada-gpu-architecture.pdf) / [Ampere GA102](https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.pdf) 白皮书）。算力列优先给公开的 **BF16/FP16、FP8 稠密**峰值（单位 PFLOPS）；「—」表示该精度不适用或未在此表展开。此处只列对照大模型时常看的几款。
+
+| 类别 | 型号 | 标称显存 | 显存带宽 | BF16/FP16 稠密 | FP8 稠密 | 显存类型 |
+| --- | --- | --- | --- | --- | --- | --- |
+| 数据中心 | [NVIDIA B200](https://www.nvidia.com/en-us/data-center/hgx/) | 180 GB | 约 7.7～8 TB/s | ≈2.25 PFLOPS | ≈4.5 PFLOPS | HBM3e |
+| 数据中心 | [NVIDIA H200](https://www.nvidia.com/en-us/data-center/h200/) | 141 GB | 4.8 TB/s | ≈0.99 PFLOPS | ≈1.98 PFLOPS | HBM3e |
+| 数据中心 | [NVIDIA H800](https://docs.nvidia.com/ai-enterprise/release-8/latest/infra-software/vgpu/reference/hopper.html) | 80 GB / 94 GB（NVL） | 约 3.35 TB/s（SXM）/ 约 3.9 TB/s（NVL） | ≈0.99 PFLOPS | ≈1.98 PFLOPS | HBM3 |
+| 数据中心 | [NVIDIA H100](https://www.nvidia.com/en-us/data-center/h100/) | 80 GB（SXM）/ 94 GB（NVL） | 3.35 TB/s（SXM）/ 3.9 TB/s（NVL） | ≈0.99 PFLOPS | ≈1.98 PFLOPS | HBM3 |
+| 数据中心 | [NVIDIA A100](https://www.nvidia.com/en-us/data-center/a100/) | 40 GB / 80 GB | 1.555 TB/s（40GB）；1.935～2.039 TB/s（80GB PCIe / SXM） | ≈0.31 PFLOPS（80GB） | — | HBM2 / HBM2e |
+| 专业卡 | [NVIDIA RTX PRO 6000 Blackwell](https://www.nvidia.com/en-us/products/workstations/professional-desktop-gpus/rtx-pro-6000/) | 96 GB | 1792 GB/s | — | — | GDDR7（ECC） |
+| 专业卡 | [NVIDIA RTX PRO 5000 Blackwell](https://www.nvidia.com/en-us/products/workstations/professional-desktop-gpus/rtx-pro-5000/) | 48 GB / 72 GB | 1344 GB/s | — | — | GDDR7（ECC） |
+| GeForce | GeForce RTX 5090 | 32 GB | 1792 GB/s | ≈1.61 PFLOPS | ≈3.3 PFLOPS | GDDR7 |
+| GeForce | GeForce RTX 4090 | 24 GB | 1008 GB/s（约 1 TB/s） | — | — | GDDR6X |
+| GeForce | GeForce RTX 3090 | 24 GB | 936 GB/s | — | — | GDDR6X |
+
+结合前文口诀与算力口径，可以很快建立量级直觉（仍要再留 KV Cache 与系统余量）：
+
+* **24 GB / ~0.9–1.0 TB/s**（3090 / 4090）：半精度约 7B～13B 较常见；INT4 下约 70B（口诀约 35 GB）单卡仍吃紧。两者容量相同，4090 带宽略高。
+* **32 GB / 1.79 TB/s / BF16 ≈1.61 PFLOPS**（5090）：消费级账面半精度算力很高，但仍远不够半精度 70B（约 140 GB）；推理小 batch 时带宽与显存往往比「再高一档 PFLOPS」更关键。
+* **48～96 GB / 1.3–1.8 TB/s**（RTX PRO 5000 / 6000）：桌面专业卡容量更高；量化后的大模型或更长上下文更现实。
+* **80～141 GB / 约 2–4.8 TB/s**（A100 / H100 / H800 / H200）：数据中心常见档位；H100/H200 的 BF16 稠密约 0.99 PFLOPS、FP8 约 1.98 PFLOPS，H200 以更大显存与更高带宽拉开推理体感。
+* **180 GB / 约 8 TB/s / BF16 ≈2.25 PFLOPS**（B200）：相对 H100/H200，显存、带宽与稠密算力同台阶抬升，更适合更大模型与更高吞吐的训练 / 推理集群。
+
+> **NOTE：**  
+> 同型号常有多种形态（如 A100 40/80 GB、H100 SXM/NVL、RTX PRO 5000 的 48/72 GB）。表中「/」表示官网并列的配置；对照时以实际机器规格为准。H800 为面向特定市场的 Hopper 产品线，显存与常见稠密算力档位与同形态 H100 对齐（差异主要在 NVLink 等互联）。算力数字均为**稠密**口径量级，若规格表另标 sparse，通常约为上表的约 2 倍，不可与稠密混比。
+
+---
+
+# 八、怎么用这套算法做判断
 
 拿到一个新模型时，可以按固定三步走：
 
 1. **读参数量**：名字或卡片上的 `B` 数字（十亿）。
 2. **读精度 / 量化档**：FP16、BF16、FP8、INT8、INT4 / NVFP4，或 GGUF 的 Q4 / Q8 等，并换算成每参数字节数 $b$（FP16/BF16 为 2，FP8/INT8 为 1，INT4/NVFP4 约 0.5）。
-3. **先算权重，再加余量，最后对照显卡**：用口诀 $M \approx B \times b$ 估权重，再用 $(B \times b) \times 1.2 + 2$ 为 KV Cache 与系统开销留余量，并与上表或本机标称显存比对。容量决定能否装下，带宽更影响吞吐；同型号可能有多种容量（如 A100 40/80 GB、H100 80/94 GB）。
+3. **先算权重，再加余量，最后对照显卡**：用口诀 $M \approx B \times b$ 估权重，再用 $(B \times b) \times 1.2 + 2$ 为 KV Cache 与系统开销留余量，并与上表或本机标称显存比对。容量决定能否装下，带宽更影响吞吐；若还要比算力，先对齐精度与稠密/稀疏口径。同型号可能有多种容量（如 A100 40/80 GB、H100 80/94 GB）。
 
 若结果已经接近或超过机器可用显存，优先考虑：换更低量化档、缩短上下文、减小 batch，或改用总参数更大但**激活参数更少**的 MoE（此时显存粗估仍常按**总参数与加载精度**看，不能只看「激活 10B」就当小模型）。更低精度能换显存与吞吐，但不等于可以跳过业务评测；训练场景还要区分 FP16 / BF16 的数值范围风险。更细的 MoE / 多卡切分问题，需要另按并行策略算，不在本文口诀范围内。
 
-一句话收束：**参数量**给出旋钮个数，**精度**给出字节密度——用二者乘一遍，再对照显卡，量级通常立刻清楚。
+一句话收束：**参数量**给出旋钮个数，**精度**给出字节密度——用二者乘一遍，再对照显卡的显存 / 带宽 / 算力口径，量级通常立刻清楚。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更

基于微信文《一文讲透AI算力单位…》语料整理改写（非照抄）：

1. **新增「六、AI 算力单位怎么评估」**（单节、无子标题）：FLOPS/TOPS、精度对齐、稠密/稀疏、峰值不可加总、带宽与 MFU、`nvidia-smi` 口径注意点。
2. **更新 GPU 对照表**（原有型号保留，只增加类型与算力列）：
   - 新增 **B200**（180 GB / 约 7.7～8 TB/s / BF16≈2.25 / FP8≈4.5）
   - 增加 **BF16/FP16 稠密**、**FP8 稠密**两列；H100/H200/H800/5090 等按公开稠密峰值填写，A100 补 BF16，专业卡与 4090/3090 算力暂标「—」

## 文件

- `_posts/2026-08-11-大模型参数量与显存估算.md`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-35a68d79-a791-4f54-9a0b-f17e48c90cbe?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35a68d79-a791-4f54-9a0b-f17e48c90cbe&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

