### PR TITLE
扩充算力评估与显存带宽，并简化 GPU 对照表

### DIFF
--- a/_posts/2026-08-11-大模型参数量与显存估算.md
+++ b/_posts/2026-08-11-大模型参数量与显存估算.md
@@ -18,7 +18,7 @@ excerpt: ""
 
 看到一个新模型发布，最常问的问题往往不是「它有多强」，而是：**我这台机器的显存够不够跑**。名字里的 `7B`、`70B`、`236B` 给出了规模量级，但真正决定显存的，是**参数个数 × 每个参数占多少字节**，再叠加推理时的上下文缓存与系统开销。
 
-本文整理一条可复用的估算路径：先分清参数量含义，再看常见精度对应的字节数与格式差异，落到一个好记的公式并说明运行时余量；最后对照常见 GPU 的显存 / 带宽 / 算力，并说明 TFLOPS、PFLOPS、TOPS 这类数字该怎么读。
+本文整理一条可复用的估算路径：先分清参数量含义，再看常见精度对应的字节数与格式差异，落到一个好记的公式并说明运行时余量；最后说明 TFLOPS / PFLOPS / TOPS 该怎么读、显存带宽为何常成瓶颈，再对照常见 GPU 的显存 / 带宽 / 算力。
 
 先给一个直觉对照：
 
@@ -159,49 +159,107 @@ $$
 
 # 六、AI 算力单位怎么评估
 
-显存回答「装不装得下」；规格表上的 TFLOPS / PFLOPS / TOPS 回答「理论上算得有多快」。同一张卡常被报出好几个差很多的数字——差别通常不在硬件本身，而在**统计口径**。读算力时，建议固定问清下面几层。
+显存回答「装不装得下」；规格表上的 TFLOPS / PFLOPS / TOPS 回答「理论上算得有多快」。同一张 RTX 5090，有人报约 1.6 PFLOPS，有人报约 3300 TOPS，还有人报约 6.6 PFLOPS——差别往往不在硬件，而在**单位、精度、是否稀疏**这三层口径。
 
-**先分清两套单位。** FLOPS（Floating Point Operations Per Second）量的是浮点运算吞吐，常见于 FP64 / FP32 / TF32 / FP16 / BF16 / FP8 / FP4；TOPS（Tera Operations Per Second）量的是整数运算吞吐，常见于 INT8 / INT4。进制上 $1\,\mathrm{PFLOPS} = 1000\,\mathrm{TFLOPS} = 10^{15}\,\mathrm{FLOPS}$，把 TFLOPS 填成 PFLOPS 时除以 1000 即可，这与精度无关。FLOPS 与 TOPS **不能互相换算，也不能相加**：即便 FP8 的 PFLOPS 与 INT8 的 TOPS 数字碰巧接近，也只是同为 8bit 位宽时吞吐「看起来像」，背后仍是两套数制与电路。
+**两套基本单位：FLOPS 与 TOPS。** FLOPS（Floating Point Operations Per Second）量浮点吞吐，常见于 FP64 / FP32 / TF32 / FP16 / BF16 / FP8 / FP4；TOPS（Tera Operations Per Second）量整数吞吐，常见于 INT8 / INT4。进制上只是十进制台阶：
 
-**再对齐精度，再比大小。** 同一套 Tensor Core 在不同精度模式下会给出不同峰值：位宽越低，单位时间能塞进的操作通常越多，账面数字越高。因此 FP16、FP8、FP4 的峰值本来就不是同一个指标；跨代、跨卡比较时，必须先固定「这是 BF16 还是 FP8」。也正因为如此，集群备案、算力普查里更常用 **BF16/FP16 稠密口径**——它仍是训练侧共识最高、最少被「换精度刷数字」带偏的基准；FP8/INT8/FP4 更适合作为部署档位，而不是唯一对标尺。
+$$
+1\,\mathrm{PFLOPS} = 1000\,\mathrm{TFLOPS} = 10^{15}\,\mathrm{FLOPS}
+$$
 
-**还要看稠密还是稀疏。** Ampere 之后常见的 2:4 结构化稀疏，理想情况下可把 Tensor Core 峰值再抬约一倍。规格表若标注 sparse / with sparsity，写的往往是这条「更好看」的曲线；多数生产模型并未严格按 2:4 稀疏部署，实际很难摸到稀疏峰值。同一款 H100，有人写约 0.99 PFLOPS（BF16 稠密）、有人写约 1.98 PFLOPS，两者都可能「对」，只是一个稠密、一个稀疏。
+例如 $1614\,\mathrm{TFLOPS} \div 1000 = 1.614\,\mathrm{PFLOPS}$，这与精度无关。FLOPS 与 TOPS **不能互相换算，也不能相加**：RTX 5090 上 FP8 约 3.3 PFLOPS、INT8 约 3300 TOPS，数字量级接近，只是因为同为 8bit、单位时间能处理的「份数」相近；一个算浮点、一个算整数，不是同一种产能。
 
-**峰值不是「可加总的总算力」。** 一张卡在 FP16、FP8、FP4、INT8 下的多个数字，描述的是同一硬件切换工作模式后的峰值，不是几路独立算力。把它们加总成「总 PFLOPS」没有意义。
+**以 RTX 5090 为例：一张卡为什么有六七个「算力」。** 公开宣传里常见这样一组理论峰值（量级示意，以厂商最新规格为准）：
 
-**理论峰值之外，还要看带宽与 MFU。** Roofline 视角里，运算强度（总浮点运算 ÷ 搬运字节）高则更偏算力受限，低则更偏带宽受限。大模型逐 token 生成常常是后者：算力数字再高，也会先卡在显存带宽。经验上，训练更同时吃算力与显存容量；小 batch 推理则经常先看带宽。厂商公布的是理想峰值；真实训练可用
+| 精度 | 理论峰值（约） |
+| --- | --- |
+| FP32 | 104 TFLOPS |
+| FP16 / BF16（Tensor Core） | 1614 TFLOPS（≈1.61 PFLOPS） |
+| FP8（Tensor Core） | ≈3.3 PFLOPS |
+| FP4（Tensor Core） | ≈6.6 PFLOPS |
+| INT8 | ≈3300 TOPS |
+| INT4 | ≈6600 TOPS |
+
+第一反应常常是：能不能把 1.61、3.3、6.6 加起来当「总算力」？**不能。** 这些数字描述的是**同一套 Tensor Core** 切到不同工作模式后的峰值，不是几路独立算力叠加——就像同一台发动机的「最高时速」和「百公里加速」不能相加成一个新指标。把 $1.61+3.3+6.6=11.5$ PFLOPS 当成总实力，口径是错的。
+
+**为什么精度越低，算力数字越高？** 核心原因很具体：位宽越小，同一块 Tensor Core 在固定「数据通路宽度」下，单位时间能塞进去处理的操作越多。粗看位宽：
+
+| 精度 | 每值位数 |
+| --- | --- |
+| FP32 | 32 bit |
+| FP16 / BF16 | 16 bit |
+| FP8 | 8 bit |
+| FP4 | 4 bit |
+
+位宽大约减半，理论上一个周期可处理的数据份数约翻倍，账面峰值也跟着上台阶——所以规格宣传里从 FP16 卷到 FP8、再卷到 FP4/INT4，数字最好看。代价同样具体：数值范围与分辨率变糙，对训练梯度更敏感。工业界更常见的是「训练偏 BF16/FP8，推理再下探 FP8/INT8/FP4」，而不是所有场景无脑上最低精度。跨卡比较时，必须先对齐「这是 BF16 还是 FP8」；集群备案也更常用 **BF16/FP16 稠密口径**，就是为了少被换精度刷数字带偏。
+
+**第三个变量：稀疏（Sparsity）。** 单位和精度之外，规格表还常藏着「稠密 / 结构化稀疏」。以 H100 SXM5 一类公开数据为例（稠密 vs 稀疏）：
+
+| 精度 | 稠密（Dense） | 结构化稀疏（Sparse） |
+| --- | --- | --- |
+| FP16 Tensor Core | ≈989.5 TFLOPS | ≈1979 TFLOPS |
+| FP8 Tensor Core | ≈1979 TFLOPS | ≈3958 TFLOPS |
+| INT8 Tensor Core | ≈1979 TOPS | ≈3958 TOPS |
+
+同一精度下，稀疏峰值大约是稠密的 **2 倍**。这来自 Ampere 之后常见的 **2:4 结构化稀疏**：权重里每 4 个数按规则清零 2 个（精度损失可控为前提），硬件对这种规律稀疏做了加速，理想吞吐可翻倍。问题在于：宣传数字经常默认报稀疏峰值；多数生产模型并没有严格按 2:4 稀疏部署，实际很难摸到那条「更好看」的曲线。所以 H100 有人写约 0.99 PFLOPS、有人写约 1.98 PFLOPS，两者都可能对——一个稠密、一个稀疏。看表时务必盯紧是否标注 sparse / with sparsity。
+
+**理论峰值还要打 MFU 折扣。** 厂商 PFLOPS 是理想上限；真实训练用
 
 $$
 \mathrm{MFU} = \frac{\text{实际有效 FLOPS}}{\text{硬件理论峰值 FLOPS}}
 $$
 
-衡量。头部大模型训练里 MFU 到约 40% 已算工程上很强，许多项目只有约 20%——通信、算子、batch/序列长度、数据加载都会把峰值「打折」。`nvidia-smi` 的 GPU-Util 只表示「采样期内有没有 kernel 在跑」，并不等于 Tensor Core 吃满，更不是 MFU；要回答「PFLOPS 用出来多少」，仍需结合 profiler / DCGM 与业务侧计量。
+衡量。峰值 1000 TFLOPS、实测有效 400 TFLOPS，则 MFU 为 40%。头部大模型训练里到约 40% 已很强，许多项目只有约 20%——带宽、多卡通信、算子、batch/序列长度、数据加载都会把峰值打折。`nvidia-smi` 的 GPU-Util 只表示「有没有 kernel 在跑」，不等于 Tensor Core 吃满，更不是 MFU。
 
 > **NOTE：**  
-> 看到任何一个算力数字，先核对四件事：浮点还是整数、哪个精度、稠密还是稀疏、理论峰值还是实测。口径没对齐时，横向比较没有信息量。
+> 看到算力数字，先问四句：浮点还是整数？哪个精度？稠密还是稀疏？理论峰值还是实测？口径没对齐，横向比较没有信息量。
 
 ---
 
-# 七、常见 GPU 显存、带宽与算力一览
+# 七、显存带宽：为什么峰值算力经常跑不满
+
+只盯 PFLOPS / TOPS 还不够。很多任务的体感瓶颈，是「喂数据」跟不上「算数据」——也就是**显存带宽**（GPU 与显存之间单位时间能搬多少字节，常见单位 GB/s、TB/s）。
+
+业内常用 Roofline（屋顶线）来判断任务偏哪边：先看**运算强度**
+
+$$
+\text{运算强度} = \frac{\text{总浮点运算次数}}{\text{需要搬运的数据字节数}}
+$$
+
+运算强度高（例如很大的稠密矩阵乘），GPU 大部分时间在算，更接近算力受限（compute-bound），才有机会摸到理论峰值附近；运算强度低（例如大模型小 batch 逐 token 生成：每次算得不多，却要反复读权重大块），GPU 大部分时间在等显存把数搬过来，就是带宽受限（memory-bound），此时再高的 PFLOPS 也先被带宽卡住。
+
+自回归解码恰恰经常落在后一类。这也是为什么推理性能讨论里，显存带宽往往和算力并列，甚至更靠前：H200 相对 H100，稠密 BF16/FP8 峰值大致同档，但带宽从约 3.35 TB/s 提到约 4.8 TB/s（约 +45% 量级），大模型推理吞吐的提升常常比「账面算力涨幅」更明显。对照下一节的表可以看到：消费级旗舰（如 5090）半精度账面算力可以很高，但 32 GB + 约 1.79 TB/s 相对数据中心卡的 HBM 容量与带宽，仍是另一条约束线。
+
+经验上可以先这样分工：
+
+* **训练大模型**：算力（PFLOPS）与显存容量都重要，带宽与互联同样会拖 MFU。
+* **推理大模型（尤其 batch 较小）**：显存带宽常常是第一瓶颈；先保证权重与 KV 装得下，再问峰值算力是否「多余」。
+
+> **NOTE：**  
+> 显存容量决定「能否驻留」；显存带宽决定「驻留之后能否持续喂饱计算」。两者和 PFLOPS 一起看，才不会只被规格表最大那个数字带跑。
+
+---
+
+# 八、常见 GPU 显存、带宽与算力一览
 
 估完模型需求后，还要对照本机「标称显存」；若关心吞吐，再看**显存带宽**与**算力峰值**。容量决定「能不能装下」，带宽更影响「算得有多顺」，算力则要在对齐精度与稠密/稀疏口径后再比。
 
 下表按 NVIDIA 官网产品页 / 规格表 / 架构白皮书整理（数据中心卡取单卡 **GPU Memory / Memory Bandwidth** 与稠密 Tensor Core 峰值；专业卡同；GeForce 容量与 50 系带宽见 [Compare GeForce Graphics Cards](https://www.nvidia.com/en-us/geforce/graphics-cards/compare/)，4090 / 3090 带宽分别见 [Ada](https://images.nvidia.com/aem-dam/Solutions/geforce/ada/nvidia-ada-gpu-architecture.pdf) / [Ampere GA102](https://www.nvidia.com/content/PDF/nvidia-ampere-ga-102-gpu-architecture-whitepaper-v2.pdf) 白皮书）。算力列优先给公开的 **BF16/FP16、FP8 稠密**峰值（单位 PFLOPS）；「—」表示该精度不适用或未在此表展开。此处只列对照大模型时常看的几款。
 
-| 类别 | 型号 | 标称显存 | 显存带宽 | BF16/FP16 稠密 | FP8 稠密 | 显存类型 |
-| --- | --- | --- | --- | --- | --- | --- |
-| 数据中心 | [NVIDIA B200](https://www.nvidia.com/en-us/data-center/hgx/) | 180 GB | 约 7.7～8 TB/s | ≈2.25 PFLOPS | ≈4.5 PFLOPS | HBM3e |
-| 数据中心 | [NVIDIA H200](https://www.nvidia.com/en-us/data-center/h200/) | 141 GB | 4.8 TB/s | ≈0.99 PFLOPS | ≈1.98 PFLOPS | HBM3e |
-| 数据中心 | [NVIDIA H800](https://docs.nvidia.com/ai-enterprise/release-8/latest/infra-software/vgpu/reference/hopper.html) | 80 GB / 94 GB（NVL） | 约 3.35 TB/s（SXM）/ 约 3.9 TB/s（NVL） | ≈0.99 PFLOPS | ≈1.98 PFLOPS | HBM3 |
-| 数据中心 | [NVIDIA H100](https://www.nvidia.com/en-us/data-center/h100/) | 80 GB（SXM）/ 94 GB（NVL） | 3.35 TB/s（SXM）/ 3.9 TB/s（NVL） | ≈0.99 PFLOPS | ≈1.98 PFLOPS | HBM3 |
-| 数据中心 | [NVIDIA A100](https://www.nvidia.com/en-us/data-center/a100/) | 40 GB / 80 GB | 1.555 TB/s（40GB）；1.935～2.039 TB/s（80GB PCIe / SXM） | ≈0.31 PFLOPS（80GB） | — | HBM2 / HBM2e |
-| 专业卡 | [NVIDIA RTX PRO 6000 Blackwell](https://www.nvidia.com/en-us/products/workstations/professional-desktop-gpus/rtx-pro-6000/) | 96 GB | 1792 GB/s | — | — | GDDR7（ECC） |
-| 专业卡 | [NVIDIA RTX PRO 5000 Blackwell](https://www.nvidia.com/en-us/products/workstations/professional-desktop-gpus/rtx-pro-5000/) | 48 GB / 72 GB | 1344 GB/s | — | — | GDDR7（ECC） |
-| GeForce | GeForce RTX 5090 | 32 GB | 1792 GB/s | ≈1.61 PFLOPS | ≈3.3 PFLOPS | GDDR7 |
-| GeForce | GeForce RTX 4090 | 24 GB | 1008 GB/s（约 1 TB/s） | — | — | GDDR6X |
-| GeForce | GeForce RTX 3090 | 24 GB | 936 GB/s | — | — | GDDR6X |
+| 型号 | 标称显存 | 显存带宽 | BF16/FP16 稠密 | FP8 稠密 | 显存类型 |
+| --- | --- | --- | --- | --- | --- |
+| [NVIDIA B200](https://www.nvidia.com/en-us/data-center/hgx/) | 180 GB | 约 7.7～8 TB/s | ≈2.25 PFLOPS | ≈4.5 PFLOPS | HBM3e |
+| [NVIDIA H200](https://www.nvidia.com/en-us/data-center/h200/) | 141 GB | 4.8 TB/s | ≈0.99 PFLOPS | ≈1.98 PFLOPS | HBM3e |
+| [NVIDIA H800](https://docs.nvidia.com/ai-enterprise/release-8/latest/infra-software/vgpu/reference/hopper.html) | 80 GB / 94 GB（NVL） | 约 3.35 TB/s（SXM）/ 约 3.9 TB/s（NVL） | ≈0.99 PFLOPS | ≈1.98 PFLOPS | HBM3 |
+| [NVIDIA H100](https://www.nvidia.com/en-us/data-center/h100/) | 80 GB（SXM）/ 94 GB（NVL） | 3.35 TB/s（SXM）/ 3.9 TB/s（NVL） | ≈0.99 PFLOPS | ≈1.98 PFLOPS | HBM3 |
+| [NVIDIA A100](https://www.nvidia.com/en-us/data-center/a100/) | 40 GB / 80 GB | 1.555 TB/s（40GB）；1.935～2.039 TB/s（80GB PCIe / SXM） | ≈0.31 PFLOPS（80GB） | — | HBM2 / HBM2e |
+| [NVIDIA RTX PRO 6000 Blackwell](https://www.nvidia.com/en-us/products/workstations/professional-desktop-gpus/rtx-pro-6000/) | 96 GB | 1792 GB/s | — | — | GDDR7（ECC） |
+| [NVIDIA RTX PRO 5000 Blackwell](https://www.nvidia.com/en-us/products/workstations/professional-desktop-gpus/rtx-pro-5000/) | 48 GB / 72 GB | 1344 GB/s | — | — | GDDR7（ECC） |
+| GeForce RTX 5090 | 32 GB | 1792 GB/s | ≈1.61 PFLOPS | ≈3.3 PFLOPS | GDDR7 |
+| GeForce RTX 4090 | 24 GB | 1008 GB/s（约 1 TB/s） | — | — | GDDR6X |
+| GeForce RTX 3090 | 24 GB | 936 GB/s | — | — | GDDR6X |
 
-结合前文口诀与算力口径，可以很快建立量级直觉（仍要再留 KV Cache 与系统余量）：
+结合前文口诀与算力口径，可以很快建立量级直觉（仍要再留 KV Cache 与系统开销）：
 
 * **24 GB / ~0.9–1.0 TB/s**（3090 / 4090）：半精度约 7B～13B 较常见；INT4 下约 70B（口诀约 35 GB）单卡仍吃紧。两者容量相同，4090 带宽略高。
 * **32 GB / 1.79 TB/s / BF16 ≈1.61 PFLOPS**（5090）：消费级账面半精度算力很高，但仍远不够半精度 70B（约 140 GB）；推理小 batch 时带宽与显存往往比「再高一档 PFLOPS」更关键。
@@ -214,7 +272,7 @@ $$
 
 ---
 
-# 八、怎么用这套算法做判断
+# 九、怎么用这套算法做判断
 
 拿到一个新模型时，可以按固定三步走：
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更说明

针对《如何从大模型参数量估算显存占用》一文，按微信推文语料润色补充：

1. **GPU 一览表**：去掉「类别」列；章节顺延为第八节。
2. **第六节「AI 算力单位怎么评估」**：补具体说明——以 RTX 5090 为例解释多口径算力、为何精度越低数字越高、结构化稀疏（2:4）与稠密/稀疏混比风险；保留 MFU 口径提醒。
3. **新增第七节「显存带宽」**：用 Roofline / 运算强度讲清算力受限 vs 带宽受限，并区分训练与小 batch 推理场景。

语料来源：https://mp.weixin.qq.com/s/PsP6dEagrTeWlLTJh0qxog（润色改写，非照抄）。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-35a68d79-a791-4f54-9a0b-f17e48c90cbe?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35a68d79-a791-4f54-9a0b-f17e48c90cbe&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

